### PR TITLE
add "qunit-plugin" keyword to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
 	"description": " headless browser testing for QUnit test suites",
 	"author": "FND",
 	"license": "Apache-2.0",
+	"keywords": [
+		"qunit",
+		"qunit-plugin",
+		"qunit-reporter",
+		"puppeteer"
+	],
 	"homepage": "https://github.com/FND/qunit-puppeteer-reporter",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
The qunitjs.com plugin registry is now based on an npm search.

Ref https://github.com/qunitjs/qunitjs.com/pull/146.